### PR TITLE
support shouldStartNameWithService setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-  "name": "serverless-apigateway-log-retention",
-  "version": "0.0.4",
-  "description": "A plugin for the Serverless framework which configures ApiGateway access adn execution log retention.",
-  "author": "Deepak Thankachan, DVLA",
-  "license": "MIT",
-  "homepage": "https://github.com/dvla/serverless-apigateway-log-retention",
-  "main": "src/serverlessApigatewayLogRetentionPlugin.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dvla/serverless-apigateway-log-retention.git"
-  },
-  "bugs": {
-    "url": "https://github.com/dvla/serverless-apigateway-log-retention/issues"
-  },
-  "keywords": [
-    "serverless",
-    "aws",
-    "api",
-    "gateway",
-    "logging",
-    "log",
-    "retention"
-  ],
-  "scripts": {
-    "test": "jest"
-  },
-  "dependencies": {
-    "aws-sdk": "^2.933.0"
-  },
-  "devDependencies": {
-    "aws-sdk-mock": "^5.2.1",
-    "jest": "^27.0.5"
-  },
-  "jest": {
-    "testEnvironment": "node",
-    "testMatch": [
-      "<rootDir>/src/__test__/*.test.js"
-    ]
-  },
-  "engines": {
-    "node": ">=8.10.0"
-  }
+    "name": "serverless-apigateway-log-retention",
+    "version": "0.0.4",
+    "description": "A plugin for the Serverless framework which configures ApiGateway access adn execution log retention.",
+    "author": "Deepak Thankachan, DVLA",
+    "license": "MIT",
+    "homepage": "https://github.com/dvla/serverless-apigateway-log-retention",
+    "main": "src/serverlessApigatewayLogRetentionPlugin.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dvla/serverless-apigateway-log-retention.git"
+    },
+    "bugs": {
+        "url": "https://github.com/dvla/serverless-apigateway-log-retention/issues"
+    },
+    "keywords": [
+        "serverless",
+        "aws",
+        "api",
+        "gateway",
+        "logging",
+        "log",
+        "retention"
+    ],
+    "scripts": {
+        "test": "jest"
+    },
+    "dependencies": {
+        "aws-sdk": "^2.933.0"
+    },
+    "devDependencies": {
+        "aws-sdk-mock": "^5.2.1",
+        "jest": "^27.0.5"
+    },
+    "jest": {
+        "testEnvironment": "node",
+        "testMatch": [
+            "<rootDir>/src/__test__/*.test.js"
+        ]
+    },
+    "engines": {
+        "node": ">=8.10.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-    "name": "serverless-apigateway-log-retention",
-    "version": "0.0.3",
-    "description": "A plugin for the Serverless framework which configures ApiGateway access adn execution log retention.",
-    "author": "Deepak Thankachan, DVLA",
-    "license": "MIT",
-    "homepage": "https://github.com/dvla/serverless-apigateway-log-retention",
-    "main": "src/serverlessApigatewayLogRetentionPlugin.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/dvla/serverless-apigateway-log-retention.git"
-    },
-    "bugs": {
-        "url": "https://github.com/dvla/serverless-apigateway-log-retention/issues"
-    },
-    "keywords": [
-        "serverless",
-        "aws",
-        "api",
-        "gateway",
-        "logging",
-        "log",
-        "retention"
-    ],
-    "scripts": {
-        "test": "jest"
-    },
-    "dependencies": {
-        "aws-sdk": "^2.933.0"
-    },
-    "devDependencies": {
-        "aws-sdk-mock": "^5.2.1",
-        "jest": "^27.0.5"
-    },
-    "jest": {
-        "testEnvironment": "node",
-        "testMatch": [
-            "<rootDir>/src/__test__/*.test.js"
-        ]
-    },
-    "engines": {
-        "node": ">=8.10.0"
-    }
+  "name": "serverless-apigateway-log-retention",
+  "version": "0.0.4",
+  "description": "A plugin for the Serverless framework which configures ApiGateway access adn execution log retention.",
+  "author": "Deepak Thankachan, DVLA",
+  "license": "MIT",
+  "homepage": "https://github.com/dvla/serverless-apigateway-log-retention",
+  "main": "src/serverlessApigatewayLogRetentionPlugin.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dvla/serverless-apigateway-log-retention.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dvla/serverless-apigateway-log-retention/issues"
+  },
+  "keywords": [
+    "serverless",
+    "aws",
+    "api",
+    "gateway",
+    "logging",
+    "log",
+    "retention"
+  ],
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.933.0"
+  },
+  "devDependencies": {
+    "aws-sdk-mock": "^5.2.1",
+    "jest": "^27.0.5"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "<rootDir>/src/__test__/*.test.js"
+    ]
+  },
+  "engines": {
+    "node": ">=8.10.0"
+  }
 }

--- a/src/serverlessApigatewayLogRetentionPlugin.js
+++ b/src/serverlessApigatewayLogRetentionPlugin.js
@@ -29,7 +29,9 @@ class ApigatewayLogRetentionPlugin {
                 limit: 500, // max limit
             })
             .promise();
-        const apiName = `${this.options.stage}-${this.serverless.service.getServiceName()}`;
+        const apiName = this.serverless.service.provider.apiGateway?.shouldStartNameWithService
+            ? `${this.serverless.service.getServiceName()}-${this.options.stage}`
+            : `${this.options.stage}-${this.serverless.service.getServiceName()}`;
         const match = apis.items.find((api) => api.name === apiName);
         if (!match) {
             throw new Error(`Api ${apiName} does not exist.`);


### PR DESCRIPTION
Hi, thank you for creating this plugin!

I have installed this plugin and notice that our serverless file include has shouldStartNameWithService flag, which will be default in serverless 3 (docs: https://www.serverless.com/framework/docs/deprecations#api-gateway-naming-will-be-changed-to-service-stage). Therefore, I update the code and create this PR to support you :)

I have also added expect.assertions(x) in the test file since we usually add this when testing async functions.

Best regards
Viet