### PR TITLE
Support over 500 APIs in a single region

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ApiGateway Log Retention
 
-Control the retention of your ApiGateway access logs and execution logs. 
+Control the retention of your ApiGateway access logs and execution logs.
 
 ## Installation
 From your target serverless project, run:
@@ -73,5 +73,3 @@ custom:
       enabled: true
       days: 7
 ```
-
-Note: This plugin might not be suitable if you have over 500 APIs in the region you are deploying to.

--- a/src/__test__/serverlessApigatewayLogRetentionPlugin.test.js
+++ b/src/__test__/serverlessApigatewayLogRetentionPlugin.test.js
@@ -150,6 +150,41 @@ describe('getRestApiId', () => {
         expect(returnedApiId).toEqual('1');
     });
 
+    test('finds matching API from over 500 RestApis', async () => {
+        expect.assertions(1);
+        awsMock.mock('APIGateway', 'getRestApis', (params, callback) => {
+            mockGetRestApisCallback(params);
+            if (mockGetRestApisCallback.mock.calls.length === 1) {
+                callback('', {
+                    items: Array(500).fill({
+                        id: '2',
+                        name: 'test1-serverless-log-retention-demo',
+                    }),
+                    position: 'next'
+                });
+            } else {
+                callback('', {
+                    items: [
+                        {
+                            id: '3',
+                            name: 'test1-serverless-log-retention-demo',
+                        },
+                        {
+                            id: '1',
+                            name: 'dev-serverless-log-retention-demo',
+                        }
+                    ],
+                    position: undefined
+                });
+            }
+        });
+
+        const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
+        const returnedApiId = await apigatewayLogRetentionPlugin.getRestApiId();
+
+        expect(returnedApiId).toEqual('1');
+    })
+
     test('support shouldStartNameWithService in serverless setting', async () => {
         expect.assertions(3);
         serverless.service.provider.apiGateway = { shouldStartNameWithService: true };


### PR DESCRIPTION
Thanks for the great plugin! I noticed the mention in README that this doesn't support cases with over 500 APIs in a single region, so here's a PR to use pagination with the `GetRestApis` API call to get _all_ APIs in a region.

The AWS API provides the pagination marker with the `position` property: <https://docs.aws.amazon.com/apigateway/latest/api/API_GetRestApis.html#API_GetRestApis_ResponseElements>

Added a simple test case.