### PR TITLE
Feature/update proxy agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The plugin uses AWS profile configured under `provider.profile` or defaults to A
 
 If you can't directly connect to the internet, the plugin supports proxy which you can set via any of the following environment variables:
 ```
-- proxy
 - HTTP_PROXY
-- http_proxy
 - HTTPS_PROXY
-- https_proxy
+- FTP_PROXY
+- WSS_PROXY
+- WS_PROXY
 ``` 
 
 By default the plugin assumes the API name format to be `[STAGE]-[SERVICE_NAME]`. If your API name format is `[SERVICE_NAME]-[STAGE]`, set `provider.apiGateway.shouldStartNameWithService` to true like so:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-apigateway-log-retention",
-    "version": "0.0.7",
+    "version": "1.0.0",
     "description": "A plugin for the Serverless framework which configures ApiGateway access adn execution log retention.",
     "author": "Deepak Thankachan, DVLA",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "aws-sdk": "^2.933.0",
-        "proxy-agent": "^5.0.0"
+        "proxy-agent": "^6.3.0"
     },
     "devDependencies": {
         "aws-sdk-mock": "^5.2.1",

--- a/src/__test__/serverlessApigatewayLogRetentionPlugin.test.js
+++ b/src/__test__/serverlessApigatewayLogRetentionPlugin.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
-const mockProxy = jest.fn();
+const { ProxyAgent } = require('proxy-agent');
 
-jest.mock('proxy-agent', () => mockProxy);
+jest.mock('proxy-agent');
 
 const awsMock = require('aws-sdk-mock');
 const Plugin = require('../serverlessApigatewayLogRetentionPlugin');
@@ -381,59 +381,54 @@ describe('useAwsProfileIfProvided', () => {
 });
 
 describe('useProxyIfConfigured', () => {
-    test('uses proxy if proxy environment variable is configured', () => {
-        expect.assertions(2);
-        process.env.proxy = 'http://proxy.com';
-
-        const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
-        apigatewayLogRetentionPlugin.useProxyIfConfigured();
-
-        expect(mockProxy).toHaveBeenCalledTimes(1);
-        expect(mockProxy).toHaveBeenCalledWith('http://proxy.com');
-    });
-
     test('uses proxy if HTTP_PROXY environment variable is configured', () => {
-        expect.assertions(2);
+        expect.assertions(1);
         process.env.HTTP_PROXY = 'http://HTTP_PROXY.com';
 
         const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
         apigatewayLogRetentionPlugin.useProxyIfConfigured();
 
-        expect(mockProxy).toHaveBeenCalledTimes(1);
-        expect(mockProxy).toHaveBeenCalledWith('http://HTTP_PROXY.com');
-    });
-
-    test('uses proxy if http_proxy environment variable is configured', () => {
-        expect.assertions(2);
-        process.env.http_proxy = 'http://http_proxy.com';
-
-        const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
-        apigatewayLogRetentionPlugin.useProxyIfConfigured();
-
-        expect(mockProxy).toHaveBeenCalledTimes(1);
-        expect(mockProxy).toHaveBeenCalledWith('http://http_proxy.com');
+        expect(ProxyAgent).toHaveBeenCalledTimes(1);
     });
 
     test('uses proxy if HTTPS_PROXY environment variable is configured', () => {
-        expect.assertions(2);
+        expect.assertions(1);
         process.env.HTTPS_PROXY = 'http://HTTPS_PROXY.com';
 
         const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
         apigatewayLogRetentionPlugin.useProxyIfConfigured();
 
-        expect(mockProxy).toHaveBeenCalledTimes(1);
-        expect(mockProxy).toHaveBeenCalledWith('http://HTTPS_PROXY.com');
+        expect(ProxyAgent).toHaveBeenCalledTimes(1);
     });
 
-    test('uses proxy if https_proxy environment variable is configured', () => {
-        expect.assertions(2);
-        process.env.https_proxy = 'http://https_proxy.com';
+    test('uses proxy if FTP_PROXY environment variable is configured', () => {
+        expect.assertions(1);
+        process.env.FTP_PROXY = 'ftp://user@host/foo/bar.txt';
 
         const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
         apigatewayLogRetentionPlugin.useProxyIfConfigured();
 
-        expect(mockProxy).toHaveBeenCalledTimes(1);
-        expect(mockProxy).toHaveBeenCalledWith('http://https_proxy.com');
+        expect(ProxyAgent).toHaveBeenCalledTimes(1);
+    });
+
+    test('uses proxy if WSS_PROXY environment variable is configured', () => {
+        expect.assertions(1);
+        process.env.WSS_PROXY = 'wss://www.example.com/';
+
+        const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
+        apigatewayLogRetentionPlugin.useProxyIfConfigured();
+
+        expect(ProxyAgent).toHaveBeenCalledTimes(1);
+    });
+
+    test('uses proxy if WS_PROXY environment variable is configured', () => {
+        expect.assertions(1);
+        process.env.WS_PROXY = 'ws://www.example.com/';
+
+        const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
+        apigatewayLogRetentionPlugin.useProxyIfConfigured();
+
+        expect(ProxyAgent).toHaveBeenCalledTimes(1);
     });
 
     test('does not use proxy if not configured', () => {
@@ -443,7 +438,7 @@ describe('useProxyIfConfigured', () => {
         const apigatewayLogRetentionPlugin = new Plugin(serverless, options);
         apigatewayLogRetentionPlugin.useProxyIfConfigured();
 
-        expect(mockProxy).toHaveBeenCalledTimes(0);
+        expect(ProxyAgent).toHaveBeenCalledTimes(0);
     });
 });
 

--- a/src/serverlessApigatewayLogRetentionPlugin.js
+++ b/src/serverlessApigatewayLogRetentionPlugin.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const proxyAgent = require('proxy-agent');
+const ProxyAgent = require('proxy-agent');
 
 const apigatewayApiVersion = '2015-07-09';
 
@@ -80,7 +80,7 @@ class ApigatewayLogRetentionPlugin {
 
         if (proxy) {
             AWS.config.update({
-                httpOptions: { agent: proxyAgent(proxy) }
+                httpOptions: { agent: new ProxyAgent(proxy) }
             });
         }
     }

--- a/src/serverlessApigatewayLogRetentionPlugin.js
+++ b/src/serverlessApigatewayLogRetentionPlugin.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const ProxyAgent = require('proxy-agent');
+const { ProxyAgent } = require('proxy-agent');
 
 const apigatewayApiVersion = '2015-07-09';
 
@@ -72,15 +72,15 @@ class ApigatewayLogRetentionPlugin {
 
     useProxyIfConfigured() {
         const proxy =
-            process.env.proxy ||
             process.env.HTTP_PROXY ||
-            process.env.http_proxy ||
             process.env.HTTPS_PROXY ||
-            process.env.https_proxy;
+            process.env.FTP_PROXY ||
+            process.env.WSS_PROXY ||
+            process.env.WS_PROXY;
 
         if (proxy) {
             AWS.config.update({
-                httpOptions: { agent: new ProxyAgent(proxy) }
+                httpOptions: { agent: new ProxyAgent() }
             });
         }
     }


### PR DESCRIPTION
Updating [proxy agent](https://www.npmjs.com/package/proxy-agent/v/6.3.0) to 6 to fix vulnerability issues

Version 6 now uses [proxy-from-env](https://www.npmjs.com/package/proxy-from-env) so there is no need to feed in the uri to the proxy agent 